### PR TITLE
u-boot-variscite: Fix for ssh issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 Change log
 -----------
 
+* Disable FORTIFY_SOURCE security feature for dropbear to fix ssh issue [Sebastian]
 * Search for flasher image only when booting from SD card [Sebastian]
 
 # v2.7.8+rev1

--- a/layers/meta-resin-imx6ul-var-dart/recipes-core/dropbear/dropbear_%.bbappend
+++ b/layers/meta-resin-imx6ul-var-dart/recipes-core/dropbear/dropbear_%.bbappend
@@ -1,0 +1,1 @@
+SECURITY_CFLAGS = "-fstack-protector-strong -pie -fpie"


### PR DESCRIPTION
The issue was fixed by disabling FORTIFY_SOURCE security
feature when compiling dropbear. The stack protection and
PIE options were left as in security_flags.inc file.