### PR TITLE
linux-variscite: Backport overlayfs patch in order to fix copy up opa…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Change log
 -----------
 
+* Fix overlayfs copy up opaqueness issue [Florin]
+
 # v2.12.7+rev1
 ## (2018-05-04)
 

--- a/layers/meta-resin-imx6ul-var-dart/recipes-kernel/linux/linux-variscite/0001-ovl-allow-zero-size-xattr.patch
+++ b/layers/meta-resin-imx6ul-var-dart/recipes-kernel/linux/linux-variscite/0001-ovl-allow-zero-size-xattr.patch
@@ -1,0 +1,34 @@
+From 97daf8b97ad6f913a34c82515be64dc9ac08d63e Mon Sep 17 00:00:00 2001
+From: Miklos Szeredi <miklos@szeredi.hu>
+Date: Tue, 10 Nov 2015 17:08:41 +0100
+Subject: [PATCH] ovl: allow zero size xattr
+
+When ovl_copy_xattr() encountered a zero size xattr no more xattrs were
+copied and the function returned success.  This is clearly not the desired
+behavior.
+
+Signed-off-by: Miklos Szeredi <miklos@szeredi.hu>
+Cc: <stable@vger.kernel.org>
+
+Upstream-Status: Backport
+Signed-off-by: Florin Sarbu <florin@resin.io>
+---
+ fs/overlayfs/copy_up.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/fs/overlayfs/copy_up.c b/fs/overlayfs/copy_up.c
+index 871fcb6..394e87f 100644
+--- a/fs/overlayfs/copy_up.c
++++ b/fs/overlayfs/copy_up.c
+@@ -54,7 +54,7 @@ int ovl_copy_xattr(struct dentry *old, struct dentry *new)
+ 
+ 	for (name = buf; name < (buf + list_size); name += strlen(name) + 1) {
+ 		size = vfs_getxattr(old, name, value, XATTR_SIZE_MAX);
+-		if (size <= 0) {
++		if (size < 0) {
+ 			error = size;
+ 			goto out_free_value;
+ 		}
+-- 
+2.7.4
+

--- a/layers/meta-resin-imx6ul-var-dart/recipes-kernel/linux/linux-variscite/0002-ovl-use-a-minimal-buffer-in-ovl_copy_xattr.patch
+++ b/layers/meta-resin-imx6ul-var-dart/recipes-kernel/linux/linux-variscite/0002-ovl-use-a-minimal-buffer-in-ovl_copy_xattr.patch
@@ -1,0 +1,92 @@
+From e4ad29fa0d224d05e08b2858e65f112fd8edd4fe Mon Sep 17 00:00:00 2001
+From: Vito Caputo <vito.caputo@coreos.com>
+Date: Sat, 24 Oct 2015 07:19:46 -0500
+Subject: [PATCH] ovl: use a minimal buffer in ovl_copy_xattr
+
+Rather than always allocating the high-order XATTR_SIZE_MAX buffer
+which is costly and prone to failure, only allocate what is needed and
+realloc if necessary.
+
+Fixes https://github.com/coreos/bugs/issues/489
+
+Signed-off-by: Miklos Szeredi <miklos@szeredi.hu>
+Cc: <stable@vger.kernel.org>
+
+Upstream-Status: Backport
+Signed-off-by: Florin Sarbu <florin@resin.io>
+---
+ fs/overlayfs/copy_up.c | 39 +++++++++++++++++++++++++--------------
+ 1 file changed, 25 insertions(+), 14 deletions(-)
+
+diff --git a/fs/overlayfs/copy_up.c b/fs/overlayfs/copy_up.c
+index 394e87f..758012b 100644
+--- a/fs/overlayfs/copy_up.c
++++ b/fs/overlayfs/copy_up.c
+@@ -22,9 +22,9 @@
+ 
+ int ovl_copy_xattr(struct dentry *old, struct dentry *new)
+ {
+-	ssize_t list_size, size;
+-	char *buf, *name, *value;
+-	int error;
++	ssize_t list_size, size, value_size = 0;
++	char *buf, *name, *value = NULL;
++	int uninitialized_var(error);
+ 
+ 	if (!old->d_inode->i_op->getxattr ||
+ 	    !new->d_inode->i_op->getxattr)
+@@ -41,29 +41,40 @@ int ovl_copy_xattr(struct dentry *old, struct dentry *new)
+ 	if (!buf)
+ 		return -ENOMEM;
+ 
+-	error = -ENOMEM;
+-	value = kmalloc(XATTR_SIZE_MAX, GFP_KERNEL);
+-	if (!value)
+-		goto out;
+-
+ 	list_size = vfs_listxattr(old, buf, list_size);
+ 	if (list_size <= 0) {
+ 		error = list_size;
+-		goto out_free_value;
++		goto out;
+ 	}
+ 
+ 	for (name = buf; name < (buf + list_size); name += strlen(name) + 1) {
+-		size = vfs_getxattr(old, name, value, XATTR_SIZE_MAX);
++retry:
++		size = vfs_getxattr(old, name, value, value_size);
++		if (size == -ERANGE)
++			size = vfs_getxattr(old, name, NULL, 0);
++
+ 		if (size < 0) {
+ 			error = size;
+-			goto out_free_value;
++			break;
++		}
++
++		if (size > value_size) {
++			void *new;
++
++			new = krealloc(value, size, GFP_KERNEL);
++			if (!new) {
++				error = -ENOMEM;
++				break;
++			}
++			value = new;
++			value_size = size;
++			goto retry;
+ 		}
++
+ 		error = vfs_setxattr(new, name, value, size, 0);
+ 		if (error)
+-			goto out_free_value;
++			break;
+ 	}
+-
+-out_free_value:
+ 	kfree(value);
+ out:
+ 	kfree(buf);
+-- 
+2.7.4
+

--- a/layers/meta-resin-imx6ul-var-dart/recipes-kernel/linux/linux-variscite/0003-ovl-don-t-copy-up-opaqueness.patch
+++ b/layers/meta-resin-imx6ul-var-dart/recipes-kernel/linux/linux-variscite/0003-ovl-don-t-copy-up-opaqueness.patch
@@ -1,0 +1,85 @@
+From 0956254a2d5b9e2141385514553aeef694dfe3b5 Mon Sep 17 00:00:00 2001
+From: Miklos Szeredi <mszeredi@redhat.com>
+Date: Mon, 8 Aug 2016 15:08:49 +0200
+Subject: [PATCH] ovl: don't copy up opaqueness
+
+When a copy up of a directory occurs which has the opaque xattr set, the
+xattr remains in the upper directory. The immediate behavior with overlayfs
+is that the upper directory is not treated as opaque, however after a
+remount the opaque flag is used and upper directory is treated as opaque.
+This causes files created in the lower layer to be hidden when using
+multiple lower directories.
+
+Fix by not copying up the opaque flag.
+
+To reproduce:
+
+ ----8<---------8<---------8<---------8<---------8<---------8<----
+mkdir -p l/d/s u v w mnt
+mount -t overlay overlay -olowerdir=l,upperdir=u,workdir=w mnt
+rm -rf mnt/d/
+mkdir -p mnt/d/n
+umount mnt
+mount -t overlay overlay -olowerdir=u:l,upperdir=v,workdir=w mnt
+touch mnt/d/foo
+umount mnt
+mount -t overlay overlay -olowerdir=u:l,upperdir=v,workdir=w mnt
+ls mnt/d
+ ----8<---------8<---------8<---------8<---------8<---------8<----
+
+output should be:  "foo  n"
+
+Reported-by: Derek McGowan <dmcg@drizz.net>
+Link: https://bugzilla.kernel.org/show_bug.cgi?id=151291
+Signed-off-by: Miklos Szeredi <mszeredi@redhat.com>
+Cc: <stable@vger.kernel.org>
+
+Upstream-Status: Backport
+Signed-off-by: Florin Sarbu <florin@resin.io>
+---
+ fs/overlayfs/copy_up.c   | 2 ++
+ fs/overlayfs/inode.c     | 2 +-
+ fs/overlayfs/overlayfs.h | 1 +
+ 3 files changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/fs/overlayfs/copy_up.c b/fs/overlayfs/copy_up.c
+index 758012b..4d8aa74 100644
+--- a/fs/overlayfs/copy_up.c
++++ b/fs/overlayfs/copy_up.c
+@@ -48,6 +48,8 @@ int ovl_copy_xattr(struct dentry *old, struct dentry *new)
+ 	}
+ 
+ 	for (name = buf; name < (buf + list_size); name += strlen(name) + 1) {
++		if (ovl_is_private_xattr(name))
++			continue;
+ retry:
+ 		size = vfs_getxattr(old, name, value, value_size);
+ 		if (size == -ERANGE)
+diff --git a/fs/overlayfs/inode.c b/fs/overlayfs/inode.c
+index ba0db26..3cf4eec 100644
+--- a/fs/overlayfs/inode.c
++++ b/fs/overlayfs/inode.c
+@@ -203,7 +203,7 @@ static int ovl_readlink(struct dentry *dentry, char __user *buf, int bufsiz)
+ }
+ 
+ 
+-static bool ovl_is_private_xattr(const char *name)
++bool ovl_is_private_xattr(const char *name)
+ {
+ 	return strncmp(name, OVL_XATTR_PRE_NAME, OVL_XATTR_PRE_LEN) == 0;
+ }
+diff --git a/fs/overlayfs/overlayfs.h b/fs/overlayfs/overlayfs.h
+index ea5a40b..a5effba 100644
+--- a/fs/overlayfs/overlayfs.h
++++ b/fs/overlayfs/overlayfs.h
+@@ -174,6 +174,7 @@ ssize_t ovl_getxattr(struct dentry *dentry, const char *name,
+ ssize_t ovl_listxattr(struct dentry *dentry, char *list, size_t size);
+ int ovl_removexattr(struct dentry *dentry, const char *name);
+ struct inode *ovl_d_select_inode(struct dentry *dentry, unsigned file_flags);
++bool ovl_is_private_xattr(const char *name);
+ 
+ struct inode *ovl_new_inode(struct super_block *sb, umode_t mode,
+ 			    struct ovl_entry *oe);
+-- 
+2.7.4
+

--- a/layers/meta-resin-imx6ul-var-dart/recipes-kernel/linux/linux-variscite_%.bbappend
+++ b/layers/meta-resin-imx6ul-var-dart/recipes-kernel/linux/linux-variscite_%.bbappend
@@ -1,5 +1,13 @@
 inherit kernel-resin
 
+FILESEXTRAPATHS_prepend_imx6ul-var-dart := "${THISDIR}/${PN}:"
+
+SRC_URI_append_imx6ul-var-dart = " \
+    file://0001-ovl-allow-zero-size-xattr.patch \
+    file://0002-ovl-use-a-minimal-buffer-in-ovl_copy_xattr.patch \
+    file://0003-ovl-don-t-copy-up-opaqueness.patch \
+"
+
 # remove the file that the BSP copies to kernel source directory (https://github.com/varigit/meta-variscite-imx/blob/Krogoth-imx-4.1.15-var01/recipes-kernel/linux/linux-variscite_4.1.15.bb#L38)
 # we need the kernel-source directory to be as close as possible to its initial state for when creating the kernel-modules-headers archive
 do_deploy_append() {


### PR DESCRIPTION
…queness issue

We backport an overlayfs opaqueness fix:

https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable.git/commit/?id=0956254a2d5b9e2141385514553aeef694dfe3b5

Patches 0001-ovl-allow-zero-size-xattr.patch and 0002-ovl-use-a-minimal-buffer-in-ovl_copy_xattr.patch are backported
solely for being able to apply the 0003-ovl-don-t-copy-up-opaqueness.patch patch with correct context.

Signed-off-by: Florin Sarbu <florin@resin.io>